### PR TITLE
Cowo changes

### DIFF
--- a/packages/garbo/src/resources/cowoResources.ts
+++ b/packages/garbo/src/resources/cowoResources.ts
@@ -27,7 +27,8 @@ export function getCowoMonstersToBanish(): Monster[] {
 
 interface BanishMethod {
   available: () => boolean;
-  macro: Macro;
+  macro: () => Macro;
+  /** Must match the name of the item or skill mafia records as the banisher. */
   name: string;
   equip?: Item | Familiar;
 }
@@ -37,13 +38,13 @@ const banishMethods: BanishMethod[] = [
     name: "Monkey Slap",
     available: () =>
       get("_monkeyPawWishesUsed") === 0 && have($item`cursed monkey's paw`),
-    macro: Macro.trySkill($skill`Monkey Slap`),
+    macro: () => Macro.trySkill($skill`Monkey Slap`),
     equip: $item`cursed monkey's paw`,
   },
   {
     name: "Spring Kick",
     available: () => have($item`spring shoes`),
-    macro: Macro.trySkill($skill`Spring Kick`).trySkill($skill`Spring Away`),
+    macro: () => Macro.trySkill($skill`Spring Kick`).trySkill($skill`Spring Away`),
     equip: $item`spring shoes`,
   },
   {
@@ -52,20 +53,20 @@ const banishMethods: BanishMethod[] = [
       myClass() === $class`Seal Clubber` &&
       have($skill`Batter Up!`) &&
       myFury() >= 5,
-    macro: Macro.trySkill($skill`Batter Up!`),
+    macro: () => Macro.trySkill($skill`Batter Up!`),
     equip: $item`seal-clubbing club`,
   },
   {
     name: "human musk",
     available: () => true,
-    macro: Macro.tryItem($item`human musk`),
+    macro: () => Macro.tryItem($item`human musk`),
   },
   {
     name: "Monodent",
     available: () =>
       have($item`Monodent of the Sea`) && get("_seadentLightningUsed", 0) < 11,
     equip: $item`Monodent of the Sea`,
-    macro: Macro.trySkill($skill`Sea *dent: Throw a Lightning Bolt`),
+    macro: () => Macro.trySkill($skill`Sea *dent: Throw a Lightning Bolt`),
   },
   /* {
     name: "Unleash Nanites",

--- a/packages/garbo/src/resources/cowoResources.ts
+++ b/packages/garbo/src/resources/cowoResources.ts
@@ -44,7 +44,8 @@ const banishMethods: BanishMethod[] = [
   {
     name: "Spring Kick",
     available: () => have($item`spring shoes`),
-    macro: () => Macro.trySkill($skill`Spring Kick`).trySkill($skill`Spring Away`),
+    macro: () =>
+      Macro.trySkill($skill`Spring Kick`).trySkill($skill`Spring Away`),
     equip: $item`spring shoes`,
   },
   {
@@ -62,7 +63,7 @@ const banishMethods: BanishMethod[] = [
     macro: () => Macro.tryItem($item`human musk`),
   },
   {
-    name: "Monodent",
+    name: "Sea *dent: Throw a Lightning Bolt",
     available: () =>
       have($item`Monodent of the Sea`) && get("_seadentLightningUsed", 0) < 11,
     equip: $item`Monodent of the Sea`,

--- a/packages/garbo/src/tasks/farm/cowo.ts
+++ b/packages/garbo/src/tasks/farm/cowo.ts
@@ -7,12 +7,24 @@ import {
   getCowoMonstersToBanish,
   redTaffyWorth,
 } from "../../resources/cowoResources";
-import { myAdventures, print, retrieveItem, toMonster } from "kolmafia";
+import {
+  Familiar,
+  Item,
+  myAdventures,
+  print,
+  retrieveItem,
+  toMonster,
+  toSlot,
+  weaponHands,
+  weaponType,
+} from "kolmafia";
 import {
   $effect,
   $item,
   $location,
   $monsters,
+  $skill,
+  $slot,
   AsdonMartin,
   FloristFriar,
   get,
@@ -23,7 +35,40 @@ import { GarboStrategy } from "../../combatStrategy";
 import { Macro } from "../../combat";
 import { trackMarginalMpa } from "../../session";
 import postCombatActions from "../../post";
-import { Quest } from "grimoire-kolmafia";
+import { Outfit, Quest } from "grimoire-kolmafia";
+
+/**
+ * Equip a banish method's gear without creating an illegal dual-wield.
+ *
+ * KoL refuses an off-hand weapon of a different WeaponType and Outfit.equip()
+ * does not check that, so dress() would fail. When dual-wielding is not legal
+ * the banish item takes the weapon slot, restoring the weapon if it will not go
+ * on.
+ * @param outfit The outfit to add the banish gear to
+ * @param thing The gear the chosen banish method needs equipped
+ * @returns Whether the gear was equipped
+ */
+function equipBanishGear(outfit: Outfit, thing: Item | Familiar): boolean {
+  if (!(thing instanceof Item) || toSlot(thing) !== $slot`weapon`) {
+    return outfit.equip(thing);
+  }
+
+  const weapon = outfit.equips.get($slot`weapon`);
+  if (!weapon) return outfit.equip(thing, $slot`weapon`);
+
+  const canDualWield =
+    !outfit.equips.has($slot`off-hand`) &&
+    have($skill`Double-Fisted Skull Smashing`) &&
+    weaponHands(weapon) === 1 &&
+    weaponHands(thing) === 1 &&
+    weaponType(weapon) === weaponType(thing);
+  if (canDualWield && outfit.equip(thing, $slot`off-hand`)) return true;
+
+  outfit.equips.delete($slot`weapon`);
+  if (outfit.equip(thing, $slot`weapon`)) return true;
+  outfit.equips.set($slot`weapon`, weapon);
+  return false;
+}
 
 export const CowoQuest: Quest<GarboTask> = {
    name: "Sea Cow Turn",
@@ -59,8 +104,13 @@ export const CowoQuest: Quest<GarboTask> = {
           });
         const banishMethod = cowoChooseBanish();
 
-        if (banishMethod?.equip) {
-          outfit.equip(banishMethod.equip);
+        if (
+          banishMethod?.equip &&
+          !equipBanishGear(outfit, banishMethod.equip)
+        ) {
+          throw new Error(
+            `Could not equip ${banishMethod.equip} to banish with ${banishMethod.name}.`,
+          );
         }
 
         return outfit;

--- a/packages/garbo/src/tasks/farm/cowo.ts
+++ b/packages/garbo/src/tasks/farm/cowo.ts
@@ -80,14 +80,14 @@ export const CowoQuest: Quest<GarboTask> = {
         if (redTaffyWorth()) {
           return Macro.if_(
             $monsters`Mer-kin rustler, sea cowboy`,
-            banishMethod?.macro ?? Macro.abort(),
+            banishMethod?.macro() ?? Macro.abort(),
           )
             .tryItem($item`pulled red taffy`)
             .meatKill();
         } else {
           return Macro.if_(
             $monsters`Mer-kin rustler, sea cowboy`,
-            banishMethod?.macro ?? Macro.abort(),
+            banishMethod?.macro() ?? Macro.abort(),
           ).meatKill();
         }
       }),

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -115,18 +115,18 @@ function createWandererOutfit(
   }
   if (needPeridot) sourceOutfit.equip($item`Peridot of Peril`);
   if (needBCZ) sourceOutfit.equip($item`blood cubic zirconia`);
+  // Take the Monodent only if it can hold the weapon slot outright, never by
+  // dual-wielding it into the off-hand. Outfit.dress() places pinned equipment
+  // with direct equip() calls rather than through the maximizer, and the checks
+  // that permit the dual-wield (Double-Fisted Skull Smashing, a one-handed
+  // weapon, canEquip) are evaluated when the outfit is built, not when it is
+  // worn -- so an off-hand placement that stops being legal in between becomes a
+  // fatal "Failed to fully dress (expected: off-hand Monodent of the Sea)".
+  // Feesh is only an optimisation, and Macro.refractedGaze() already gates the
+  // skill on haveEquipped(), so declining it costs a wanderer trick rather than
+  // the whole run.
   if (needMonodent) {
-    sourceOutfit.equip($item`Monodent of the Sea`);
-    // The Monodent is a one-handed weapon, so when the weapon slot is already
-    // spoken for grimoire dual-wields it into the off-hand. That only pins the
-    // off-hand: if nothing pins the weapon, the maximizer is still free to pick
-    // a two-handed weapon, which makes the off-hand unreachable and turns
-    // dress() into a hard "Failed to fully dress" that kills the whole run.
-    // Mafia imposes exactly this restriction on itself when it pins an off-hand
-    // (Evaluator sets hands = 1), so state it explicitly here.
-    if (sourceOutfit.haveEquipped($item`Monodent of the Sea`, $slot`off-hand`)) {
-      sourceOutfit.modifier.push("1 hand");
-    }
+    sourceOutfit.equip($item`Monodent of the Sea`, $slot`weapon`);
   }
 
   return freeFightOutfit(

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -117,20 +117,9 @@ function createWandererOutfit(
   }
   if (needPeridot) sourceOutfit.equip($item`Peridot of Peril`);
   if (needBCZ) sourceOutfit.equip($item`blood cubic zirconia`);
-  // KoL only lets you dual-wield two weapons of the same type -- see
-  // EquipmentRequest: "You can't hold a <x> in your off-hand when wielding a
-  // <y>" when getWeaponType differs. Outfit.equipUsingDualWield() checks
-  // handedness, Double-Fisted Skull Smashing and canEquip, but not weapon type,
-  // so it will happily pin the Monodent (a one-handed spear, melee) opposite
-  // something like an ice nine (a one-handed pistol, ranged). Nothing catches
-  // that until dress() applies the pinned slots with direct equip() calls, the
-  // game refuses, and the run dies on "Failed to fully dress".
-  //
-  // So only place the Monodent where it is certain to be equippable: the weapon
-  // slot if the outfit has not claimed it, or the off-hand beside a weapon we
-  // have actually pinned and checked. Feesh is an optimisation and
-  // Macro.refractedGaze() gates the skill on haveEquipped(), so declining it
-  // costs a wanderer trick rather than the whole run.
+  // KoL only lets you dual-wield two weapons of the same type and
+  // Outfit.equipUsingDualWield() does not check that, so place the Monodent only
+  // where it is certain to be equippable. Feesh is optional.
   if (needMonodent) {
     const monodent = $item`Monodent of the Sea`;
     const plannedWeapon = sourceOutfit.equips.get($slot`weapon`);

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -14,6 +14,8 @@ import {
   totalTurnsPlayed,
   use,
   visitUrl,
+  weaponHands,
+  weaponType,
 } from "kolmafia";
 import {
   $effect,
@@ -115,18 +117,31 @@ function createWandererOutfit(
   }
   if (needPeridot) sourceOutfit.equip($item`Peridot of Peril`);
   if (needBCZ) sourceOutfit.equip($item`blood cubic zirconia`);
-  // Take the Monodent only if it can hold the weapon slot outright, never by
-  // dual-wielding it into the off-hand. Outfit.dress() places pinned equipment
-  // with direct equip() calls rather than through the maximizer, and the checks
-  // that permit the dual-wield (Double-Fisted Skull Smashing, a one-handed
-  // weapon, canEquip) are evaluated when the outfit is built, not when it is
-  // worn -- so an off-hand placement that stops being legal in between becomes a
-  // fatal "Failed to fully dress (expected: off-hand Monodent of the Sea)".
-  // Feesh is only an optimisation, and Macro.refractedGaze() already gates the
-  // skill on haveEquipped(), so declining it costs a wanderer trick rather than
-  // the whole run.
+  // KoL only lets you dual-wield two weapons of the same type -- see
+  // EquipmentRequest: "You can't hold a <x> in your off-hand when wielding a
+  // <y>" when getWeaponType differs. Outfit.equipUsingDualWield() checks
+  // handedness, Double-Fisted Skull Smashing and canEquip, but not weapon type,
+  // so it will happily pin the Monodent (a one-handed spear, melee) opposite
+  // something like an ice nine (a one-handed pistol, ranged). Nothing catches
+  // that until dress() applies the pinned slots with direct equip() calls, the
+  // game refuses, and the run dies on "Failed to fully dress".
+  //
+  // So only place the Monodent where it is certain to be equippable: the weapon
+  // slot if the outfit has not claimed it, or the off-hand beside a weapon we
+  // have actually pinned and checked. Feesh is an optimisation and
+  // Macro.refractedGaze() gates the skill on haveEquipped(), so declining it
+  // costs a wanderer trick rather than the whole run.
   if (needMonodent) {
-    sourceOutfit.equip($item`Monodent of the Sea`, $slot`weapon`);
+    const monodent = $item`Monodent of the Sea`;
+    const plannedWeapon = sourceOutfit.equips.get($slot`weapon`);
+    if (!plannedWeapon) {
+      sourceOutfit.equip(monodent, $slot`weapon`);
+    } else if (
+      weaponHands(plannedWeapon) === 1 &&
+      weaponType(plannedWeapon) === weaponType(monodent)
+    ) {
+      sourceOutfit.equip(monodent, $slot`off-hand`);
+    }
   }
 
   return freeFightOutfit(

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -23,6 +23,7 @@ import {
   $location,
   $monster,
   $skill,
+  $slot,
   ChestMimic,
   Counter,
   CrepeParachute,
@@ -114,7 +115,19 @@ function createWandererOutfit(
   }
   if (needPeridot) sourceOutfit.equip($item`Peridot of Peril`);
   if (needBCZ) sourceOutfit.equip($item`blood cubic zirconia`);
-  if (needMonodent) sourceOutfit.equip($item`Monodent of the Sea`);
+  if (needMonodent) {
+    sourceOutfit.equip($item`Monodent of the Sea`);
+    // The Monodent is a one-handed weapon, so when the weapon slot is already
+    // spoken for grimoire dual-wields it into the off-hand. That only pins the
+    // off-hand: if nothing pins the weapon, the maximizer is still free to pick
+    // a two-handed weapon, which makes the off-hand unreachable and turns
+    // dress() into a hard "Failed to fully dress" that kills the whole run.
+    // Mafia imposes exactly this restriction on itself when it pins an off-hand
+    // (Evaluator sets hands = 1), so state it explicitly here.
+    if (sourceOutfit.haveEquipped($item`Monodent of the Sea`, $slot`off-hand`)) {
+      sourceOutfit.modifier.push("1 hand");
+    }
+  }
 
   return freeFightOutfit(
     sourceOutfit.spec(),


### PR DESCRIPTION
Monodent wandering (wanderer.ts): KoL only allows dual-wielding two one-handed weapons of the same type, and Outfit.equipUsingDualWield() doesn't check type, so dress() could fail. The Monodent now takes the weapon slot when none is planned, goes to the off-hand only alongside a one-handed same-type weapon, and feesh is skipped otherwise.

Banish macros (cowoResources.ts): BanishMethod.macro is now () => Macro and every entry is a thunk, deferring macro construction to use time.

Banish gear (farm/cowo.ts): banish equipment goes through a dual-wield-safe helper with the same legality rules as the wanderer, falling back to the weapon slot and throwing if the gear can't be equipped at all.

Banish bookkeeping (cowoResources.ts): the Monodent method is renamed to Sea *dent: Throw a Lightning Bolt — the name mafia actually records — so banishMethodInUse() recognizes it and stops re-firing the size-1 banish, which released the previously banished monster.